### PR TITLE
Add template dependencies to outer build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,12 @@ lazy val root = (project in file("."))
   .enablePlugins(ScriptedPlugin)
   .settings(
     name := "typelevel.g8",
+    libraryDependencies ++= Seq(
+      "org.typelevel" %%% "cats-core" % "2.7.0",
+      "org.typelevel" %%% "cats-effect" % "3.3.9",
+      "org.scalameta" %%% "munit" % "0.7.29" % Test,
+      "org.typelevel" %%% "munit-cats-effect-3" % "1.0.7" % Test
+    ),
     Test / test := {
       val _ = (Test / g8Test).toTask("").value
     },

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -6,7 +6,6 @@ organization_name = Example
 
 scala_version = 2.13.8
 other_scala_version = 3.1.1
-sbt_version = 1.6.2
 jdk_version = 8
 
 github_username = valencik

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -7,7 +7,6 @@ organization_name = Example
 scala_version = 2.13.8
 other_scala_version = 3.1.1
 sbt_version = 1.6.2
-sbt_typelevel_version = 0.4.7
 jdk_version = 8
 
 github_username = valencik

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.typelevel" % "sbt-typelevel" % "$sbt_typelevel_version$")
-addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % "$sbt_typelevel_version$")
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.9")
+addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % "0.4.9")


### PR DESCRIPTION
Addresses https://github.com/typelevel/typelevel.g8/issues/13

This will get our library dependencies managed by Scala Steward.
It won't help us with our ~sbt or~ scala versions though.

Edit: Our sbt version will actually be updated by Scala Steward afterall