### PR TITLE
Fix Scala Steward Not Updating Inner Plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.11")
+addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % "0.4.11")
 addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.14.0")

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.11")
-addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % "0.4.9")
+addSbtPlugin("org.typelevel" % "sbt-typelevel-site" % "0.4.11")


### PR DESCRIPTION
Scala Steward will only update dependencies within the template if they are dependencies in the outside project.
So here we add all the inner plugins to the outer project.