### PR TITLE
Ignore .direnv and .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ metals.sbt
 
 # npm
 node_modules/
+
+# nix
+.direnv/
+
+# macOS
+.DS_Store


### PR DESCRIPTION
Adds two new entries to the .gitignore

One for the common macOS metadata file .DS_Store
And .direnv which is often used in combination with nix