### PR TITLE
Add hook to update inner workflow

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,6 @@
+postUpdateHooks = [{
+  command = ["update-inner-workflows.sh"],
+  commitMessage = "Regenerated inner workflows",
+  groupId = "org.typelevel",
+  artifactId = "sbt-typelevel"
+}]

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,5 @@
 postUpdateHooks = [{
-  command = ["update-inner-workflows.sh"],
+  command = ["./update-inner-workflows.sh"],
   commitMessage = "Regenerated inner workflows",
   groupId = "org.typelevel",
   artifactId = "sbt-typelevel"

--- a/update-inner-workflows.sh
+++ b/update-inner-workflows.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env bash
+# exit when any command fails
+set -e
+
+echo "Hijacking giter8.test"
+cat << EOF > project/giter8.test
+> githubWorkflowGenerate
+$ exec cp .github/workflows/ci.yml $(pwd)/src/main/g8/.github/workflows/ci.yml
+EOF
+
+echo "Running hijacked giter8.test to copy new workflow"
+sbt g8Test
+
+echo "Restoring original giter8.test"
+git restore project/giter8.test
+
+echo "Running original giter8.test"
+sbt g8Test
+
+echo "inner github workflows have been regenerated"
+git status

--- a/update-inner-workflows.sh
+++ b/update-inner-workflows.sh
@@ -16,6 +16,3 @@ git restore project/giter8.test
 
 echo "Running original giter8.test"
 sbt g8Test
-
-echo "inner github workflows have been regenerated"
-git status


### PR DESCRIPTION
Now Steward will update our inner github workflows automatically.

This works by having Steward run a script via a post update hook.
That script then regenerates the workflows, copies the new workflow files outside the sbt scripted environment, and finally runs the regular scripted test to make sure everything is good. Steward then commits the changes. 

This PR closes https://github.com/typelevel/typelevel.g8/issues/30
It was tested in https://github.com/typelevel/typelevel.g8/pull/63
And supersedes a previous and somewhat complex attempt in https://github.com/typelevel/typelevel.g8/pull/47