### PR TITLE
scalafmt: override runner dialect for scala3

### DIFF
--- a/src/main/g8/.scalafmt.conf
+++ b/src/main/g8/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.4.3
+version = 3.7.1
 runner.dialect = scala213
 
 fileOverride {

--- a/src/main/g8/.scalafmt.conf
+++ b/src/main/g8/.scalafmt.conf
@@ -1,2 +1,8 @@
 version = 3.4.3
 runner.dialect = scala213
+
+fileOverride {
+  "glob:**/scala-3/**" {
+    runner.dialect = scala3
+  }
+}


### PR DESCRIPTION
Cross-compiling projects need this so scala-3 code doesn't fail during formatting (and also so it gets formatted nicely!)

<details><summary> This was an issue for snakecase, details within </summary>

you can see the [failing CI here](https://github.com/cozydev-pink/snakecase/actions/runs/4227309734/jobs/7341652771)
and the specific error we were getting is:

```sbt
[error] org.scalafmt.sbt.ScalafmtSbtReporter$ScalafmtSbtError: scalafmt: /home/runner/work/snakecase/snakecase/core/shared/src/main/scala-3/pink/cozydev/snakecase/literals.scala:31: error: unclosed character literal
[error]         case Right(_) => Right('{SnakeCase.unsafeFromString(${Expr(s)})})
[error]                                ^ [/home/runner/work/snakecase/snakecase/core/shared/src/main/scala-3/pink/cozydev/snakecase/literals.scala]
[error] (coreJS / Compile / scalafmtCheck) org.scalafmt.sbt.ScalafmtSbtReporter$ScalafmtSbtError: scalafmt: /home/runner/work/snakecase/snakecase/core/shared/src/main/scala-3/pink
```
</details>

This override was the necessary bit to get things passing, and seems like a nice thing to offer out-of-the-box.
It shouldn't cause any problems for folks without a scala-3 directory, and should "just work" for folks that do