### PR TITLE
Update CODE_OF_CONDUCT for new TL CoC

### DIFF
--- a/src/main/g8/CODE_OF_CONDUCT.md
+++ b/src/main/g8/CODE_OF_CONDUCT.md
@@ -1,8 +1,8 @@
 # Code of Conduct
 
-We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other such characteristics.
+Every member of our community has the right to have their identity respected. The Typelevel community is dedicated to providing a positive experience for everyone, regardless of age, gender identity and expression, sexual orientation, disability, neurodivergence, physical appearance, body size, ethnicity, nationality, race, or religion (or lack thereof), education, or socio-economic status.
 
-Everyone is expected to follow the [Scala Code of Conduct] when discussing the project on the available communication channels.
+Everyone is expected to follow the [Typelevel Code of Conduct] when discussing the project on the available communication channels.
 
 
 ## Moderation
@@ -11,4 +11,4 @@ If you have any questions, concerns, or moderation requests, please contact a me
 
 - [$contributor_name$](mailto:$contributor_email$)
 
-[Scala Code of Conduct]: https://scala-lang.org/conduct/
+[Typelevel Code of Conduct]: https://typelevel.org/code-of-conduct


### PR DESCRIPTION
This PR updates the template CODE_OF_CONDUCT file to point to the new Typelevel code of conduct, and additionally use the new language from it.