### PR TITLE
Update Java versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         scala: [2.12]
-        java: [temurin@8, temurin@17]
+        java: [temurin@8, temurin@21]
+        exclude:
+          - os: macos-latest
+            java: temurin@8
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -55,17 +58,17 @@ jobs:
         if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
         run: sbt +update
 
-      - name: Setup Java (temurin@17)
-        id: setup-java-temurin-17
-        if: matrix.java == 'temurin@17'
+      - name: Setup Java (temurin@21)
+        id: setup-java-temurin-21
+        if: matrix.java == 'temurin@21'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
+        if: matrix.java == 'temurin@21' && steps.setup-java-temurin-21.outputs.cache-hit == 'false'
         run: sbt +update
 
       - name: Check that workflows are up to date

--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,13 @@ val MacOS = "macos-latest"
 ThisBuild / githubWorkflowOSes := Seq(PrimaryOS, MacOS)
 
 val PrimaryJava = JavaSpec.temurin("8")
-val LTSJava = JavaSpec.temurin("17")
+val LTSJava = JavaSpec.temurin("21")
 ThisBuild / githubWorkflowJavaVersions := Seq(PrimaryJava, LTSJava)
+
+// MacOS runners do not have temurin@8
+ThisBuild / githubWorkflowBuildMatrixExclusions := Seq(
+  MatrixExclude(Map("os" -> MacOS, "java" -> JavaSpec.temurin("8").render))
+)
 
 // This build is for this Giter8 template.
 // To test the template run `g8` or `g8Test` from the sbt session.


### PR DESCRIPTION
- Drops Java 8 on MacOS, which no longer exists.  Fixes #148.
- Bumps LTS version to 21.  There's nothing special about 17 anymore.