### PR TITLE
Fix overlay reference in flake.nix

### DIFF
--- a/src/main/g8/flake.nix
+++ b/src/main/g8/flake.nix
@@ -10,7 +10,7 @@
       let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [ typelevel-nix.overlay ];
+          overlays = [ typelevel-nix.overlays.default ];
         };
       in
       {


### PR DESCRIPTION
This is basically #150, but for the generated flake.