### PR TITLE
Add `year` template variable

### DIFF
--- a/src/main/g8/NOTICE
+++ b/src/main/g8/NOTICE
@@ -1,3 +1,3 @@
 $name$
-Copyright 2023 $organization_name$
+Copyright $year$ $organization_name$
 Licensed under Apache License 2.0 (see LICENSE)

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -3,7 +3,7 @@ ThisBuild / tlBaseVersion := "0.0" // your current series x.y
 
 ThisBuild / organization := "$organization$"
 ThisBuild / organizationName := "$organization_name$"
-ThisBuild / startYear := Some(2024)
+ThisBuild / startYear := Some($year$)
 ThisBuild / licenses := Seq(License.Apache2)
 ThisBuild / developers := List(
   // your GitHub handle and name

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -3,7 +3,7 @@ ThisBuild / tlBaseVersion := "0.0" // your current series x.y
 
 ThisBuild / organization := "$organization$"
 ThisBuild / organizationName := "$organization_name$"
-ThisBuild / startYear := Some(2023)
+ThisBuild / startYear := Some(2024)
 ThisBuild / licenses := Seq(License.Apache2)
 ThisBuild / developers := List(
   // your GitHub handle and name

--- a/src/main/g8/core/src/main/scala/$package$/Main.scala
+++ b/src/main/g8/core/src/main/scala/$package$/Main.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 $organization_name$
+ * Copyright $year$ $organization_name$
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/g8/core/src/test/scala/$package$/MainSuite.scala
+++ b/src/main/g8/core/src/test/scala/$package$/MainSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 $organization_name$
+ * Copyright $year$ $organization_name$
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -3,6 +3,7 @@ description = Template using sbt-typelevel
 organization = com.example
 package = $organization$.$name;format="norm,word"$
 organization_name = Example
+year = 2024
 
 scala_version = 2.13.14
 other_scala_version = 3.3.3


### PR DESCRIPTION
This PR adds a new template variable `year` which is used in the build.sbt `startYear` and copyright headers.

Resolves https://github.com/typelevel/typelevel.g8/issues/138

Also it's a little test that all the recent merges left us with a good CI setup. :)