### PR TITLE
Revert "Update sbt, scripted-plugin to 1.10.8"

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.8
+sbt.version=1.10.7

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.8
+sbt.version=1.10.7


### PR DESCRIPTION
Reverts typelevel/typelevel.g8#198

As per https://github.com/sbt/sbt/releases/tag/v1.10.8, sbt 1.10.8 shouldn't be used.